### PR TITLE
Updating cucumber to 2.0.1 causes tests to not recognize step.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     builder (3.2.2)
     childprocess (0.5.6)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (2.0.1)
+    cucumber (2.0.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.2.0)
       diff-lcs (>= 1.1.3)


### PR DESCRIPTION
files. Revert cucumber version to make the test run while we
figure out what the problem is with 2.0.1