### PR TITLE
Delete all household accounts per scenario

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,10 +63,9 @@ After do |scenario|
 
   #CLOBBER OBJECTS TO PREVENT FAILURES FROM POLLUTING DOWNSTREAM TESTS
   #IF THE OBJECT IS ALREADY DELETED THIS IS A NOOP
-  delete_account_via_api
   delete_contact_via_api
   delete_contacts_via_api
   delete_opportunity_via_api
   delete_open_opportunities
-  delete_recurring_donations
+  delete_household_accounts
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -67,5 +67,6 @@ After do |scenario|
   delete_contacts_via_api
   delete_opportunity_via_api
   delete_open_opportunities
+  delete_recurring_donations
   delete_household_accounts
 end

--- a/features/support/modules/sfdc_api.rb
+++ b/features/support/modules/sfdc_api.rb
@@ -61,6 +61,15 @@ def delete_opportunity_via_api
   end
 end
 
+def delete_household_accounts
+  api_client do
+    rd_opps = @api_client.query("select Id from Account where Type = 'Household'")
+    rd_opps.each do |opp|
+      opp.destroy
+    end
+  end
+end
+
 def delete_open_opportunities
   api_client do
     rd_opps = @api_client.query("select Id from Opportunity where IsClosed = false")

--- a/features/support/modules/sfdc_api.rb
+++ b/features/support/modules/sfdc_api.rb
@@ -64,8 +64,8 @@ end
 def delete_household_accounts
   api_client do
     rd_opps = @api_client.query("select Id from Account where Type = 'Household'")
-    rd_opps.each do |opp|
-      opp.destroy
+    rd_opps.each do |hh|
+      hh.destroy
     end
   end
 end


### PR DESCRIPTION
Creating Contacts automatically creates Households for those Contacts,
we need to remove those when the test is done.

Note that the delete_account_via_api is still useful within certain
tests but no longer useful in the After teardown.